### PR TITLE
Removed waiting for react context & side effects of not having one

### DIFF
--- a/detox/android/detox/src/main/java/com/wix/detox/ReactNativeCompat.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/ReactNativeCompat.java
@@ -33,7 +33,7 @@ public class ReactNativeCompat {
             // ReactNativeSupport.waitForReactNativeLoad(reactNativeHostHolder);
             try {
                 //TODO- Temp hack to make Detox usable for RN>=50 till we find a better sync solution.
-                Thread.sleep(5 * 1000);
+                Thread.sleep(1000);
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }

--- a/detox/android/detox/src/main/java/com/wix/detox/ReactNativeCompat.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/ReactNativeCompat.java
@@ -30,10 +30,10 @@ public class ReactNativeCompat {
 
     public static void waitForReactNativeLoad(Context reactNativeHostHolder) {
         if (getMinor() >= 50) {
-            ReactNativeSupport.waitForReactNativeLoad(reactNativeHostHolder);
+            // ReactNativeSupport.waitForReactNativeLoad(reactNativeHostHolder);
             try {
                 //TODO- Temp hack to make Detox usable for RN>=50 till we find a better sync solution.
-                Thread.sleep(1000);
+                Thread.sleep(5 * 1000);
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }

--- a/detox/android/detox/src/main/java/com/wix/detox/ReactNativeSupport.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/ReactNativeSupport.java
@@ -237,12 +237,12 @@ public class ReactNativeSupport {
 
         Log.i(LOG_TAG, "Removing Espresso IdlingResources for React Native.");
 
-        IdlingRegistry.getInstance().unregister(rnTimerIdlingResource);
-        IdlingRegistry.getInstance().unregister(rnBridgeIdlingResource);
-        IdlingRegistry.getInstance().unregister(rnUIModuleIdlingResource);
-        IdlingRegistry.getInstance().unregister(animIdlingResource);
+        // IdlingRegistry.getInstance().unregister(rnTimerIdlingResource);
+        // IdlingRegistry.getInstance().unregister(rnBridgeIdlingResource);
+        // IdlingRegistry.getInstance().unregister(rnUIModuleIdlingResource);
+        // IdlingRegistry.getInstance().unregister(animIdlingResource);
 
-        reactContext.getCatalystInstance().removeBridgeIdleDebugListener(rnBridgeIdlingResource);
+        // reactContext.getCatalystInstance().removeBridgeIdleDebugListener(rnBridgeIdlingResource);
     }
 
     private static boolean networkSyncEnabled = true;

--- a/detox/android/detox/src/main/java/com/wix/detox/ReactNativeSupport.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/ReactNativeSupport.java
@@ -310,6 +310,8 @@ public class ReactNativeSupport {
     }
 
     public static void resumeRNTimersIdlingResource() {
-        rnTimerIdlingResource.resume();
+        if (rnTimerIdlingResource != null) {
+            rnTimerIdlingResource.resume();
+        }
     }
 }

--- a/detox/android/detox/src/main/java/com/wix/detox/ReactNativeSupport.java
+++ b/detox/android/detox/src/main/java/com/wix/detox/ReactNativeSupport.java
@@ -234,15 +234,18 @@ public class ReactNativeSupport {
     }
 
     private static void removeEspressoIdlingResources(ReactContext reactContext) {
-
+        if(reactContext == null) {
+            return;
+        }
+        
         Log.i(LOG_TAG, "Removing Espresso IdlingResources for React Native.");
 
-        // IdlingRegistry.getInstance().unregister(rnTimerIdlingResource);
-        // IdlingRegistry.getInstance().unregister(rnBridgeIdlingResource);
-        // IdlingRegistry.getInstance().unregister(rnUIModuleIdlingResource);
-        // IdlingRegistry.getInstance().unregister(animIdlingResource);
+        IdlingRegistry.getInstance().unregister(rnTimerIdlingResource);
+        IdlingRegistry.getInstance().unregister(rnBridgeIdlingResource);
+        IdlingRegistry.getInstance().unregister(rnUIModuleIdlingResource);
+        IdlingRegistry.getInstance().unregister(animIdlingResource);
 
-        // reactContext.getCatalystInstance().removeBridgeIdleDebugListener(rnBridgeIdlingResource);
+        reactContext.getCatalystInstance().removeBridgeIdleDebugListener(rnBridgeIdlingResource);
     }
 
     private static boolean networkSyncEnabled = true;


### PR DESCRIPTION
[Clubhouse Story](https://app.clubhouse.io/feeld/story/12212/detox-setup)

This task realtes to [this PR]()

### SUMMARY

I've commented out waiting for react native to load as it crashes being unable to getCurrentReactContext. This results in not creating idling resources, thus checks for reactContext/idlingResources being null before acting on them.

https://github.com/Feeld/Detox/blob/5ffab4f6aaafdacb5c97fae655a02a256249305a/detox/android/detox/src/main/java/com/wix/detox/ReactNativeSupport.java#L147-L170